### PR TITLE
Fix trips warnings

### DIFF
--- a/apis/trips/glide.yaml
+++ b/apis/trips/glide.yaml
@@ -5,7 +5,9 @@ import:
 - package: github.com/denisenkom/go-mssqldb
 - package: github.com/gorilla/mux
   version: ~1.6.2
-testImport:
+- package: github.com/stretchr/testify
+  version: ~1.2.2
+  testImport:
 - package: github.com/stretchr/testify
   version: ~1.2.2
   subpackages:

--- a/apis/trips/glide.yaml
+++ b/apis/trips/glide.yaml
@@ -7,8 +7,3 @@ import:
   version: ~1.6.2
 - package: github.com/stretchr/testify
   version: ~1.2.2
-  testImport:
-- package: github.com/stretchr/testify
-  version: ~1.2.2
-  subpackages:
-  - assert

--- a/apis/trips/go.mod
+++ b/apis/trips/go.mod
@@ -1,14 +1,14 @@
 module github.com/Azure-Samples/openhack-devops-team/apis/trips
 
 require (
-	cloud.google.com/go v0.0.0-20180627205256-45528feae6df
+	cloud.google.com/go v0.0.0-20180627205256-45528feae6df // indirect
 	github.com/codemodus/swagui v0.1.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20180625034930-3724b4745ca9
-	github.com/gorilla/context v1.1.1
+	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
-	golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8
+	golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8 // indirect
 )

--- a/apis/trips/tripsgo/test_util.go
+++ b/apis/trips/tripsgo/test_util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// APITestCase needs to be exported to be accessed for test dir
 type APITestCase struct {
 	Tag              string
 	Method           string
@@ -34,6 +35,7 @@ func testAPI(router *mux.Router, method, URL, body string) *httptest.ResponseRec
 	return res
 }
 
+// RunAPITests needs to be exported to be accessed for test dir
 func RunAPITests(t *testing.T, router *mux.Router, tests []APITestCase) {
 	for i := 0; i < len(tests); i++ {
 		res := testAPI(router, tests[i].Method, tests[i].URL, tests[i].Body)


### PR DESCRIPTION
## Purpose
- fix test export warnings
- update go.mod file with changes automatically made when running `go mod vendor`
- Fix glide lockfile error