### PR TITLE
Updating to reflect new name for VSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To understand each of the components above in more detail, please visit the read
 It is useful but not required to have a basic knowledge of the following topics:
 
 * Kubernetes
-* VSTS or Jenkins
+* Azure DevOps (formally VSTS) or Jenkins
 
 ## Resources
 


### PR DESCRIPTION
Just updating the readme so we indicate both the new name (Azure DevOps) and old name (VSTS).