### PR TITLE
remove imagePullSecrets

### DIFF
--- a/apis/poi/helm/templates/deployment.yaml
+++ b/apis/poi/helm/templates/deployment.yaml
@@ -14,8 +14,6 @@ spec:
       labels:
         app: {{ .Values.image.label }}
     spec:
-      imagePullSecrets:
-      - name: acrsecret
       containers:
       - image: "{{ .Values.repository.image }}:{{ .Values.repository.tag }}"
         imagePullPolicy: {{ .Values.repository.pullPolicy }}

--- a/apis/trips/helm/templates/deployment.yaml
+++ b/apis/trips/helm/templates/deployment.yaml
@@ -14,8 +14,6 @@ spec:
       labels:
         app: {{ .Values.image.label }}
     spec:
-      imagePullSecrets:
-        - name: acrsecret
       containers:
       - image: "{{ .Values.repository.image }}:{{ .Values.repository.tag }}"
         imagePullPolicy: {{ .Values.repository.pullPolicy }}

--- a/apis/userprofile/helm/templates/deployment.yaml
+++ b/apis/userprofile/helm/templates/deployment.yaml
@@ -14,8 +14,6 @@ spec:
       labels:
         app: {{ .Values.image.label }}
     spec:
-      imagePullSecrets:
-      - name: acrsecret
       containers:
       - image: "{{ .Values.repository.image }}:{{ .Values.repository.tag }}"
         imagePullPolicy: {{ .Values.repository.pullPolicy }}


### PR DESCRIPTION
## Purpose
Removes the `imagePullSecrets` from all the deployments since we have authenticated AKS to allow pulls for all images to ACR [here](https://github.com/Azure-Samples/openhack-devops-proctor/blob/116ad389de9015e5c2d37db716cf6358f693843e/provision-team/provision_aks.sh#L100).