### PR TITLE
trips golang 1.11.1, alpine 3.8 docker images

### DIFF
--- a/apis/trips/Dockerfile
+++ b/apis/trips/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.0 AS gobuild
+FROM golang:1.11.1 AS gobuild
 
 WORKDIR /go/src/github.com/Azure-Samples/openhack-devops-team/apis/trips
 
@@ -6,11 +6,11 @@ COPY . .
 
 ENV GO111MODULE=on
 
-RUN go mod vendor
+RUN go get
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o main .
 
-FROM alpine:3.7 AS gorun
+FROM alpine:3.8 AS gorun
 
 ENV SQL_USER="YourUserName" \
 SQL_PASSWORD="changeme" \

--- a/apis/trips/README.md
+++ b/apis/trips/README.md
@@ -19,13 +19,13 @@ go run main.go
 To run unit tests, execute:
 
 ```shell
-go test ./test
+go test ./tests
 ```
 
-To run integration tests, execute:
+To run all integration tests, execute:
 
 ```shell
-go test ./test/integration
+go test
 ```
 
 > Note: this requires an actual database connection, so the required ENV variables need to be present.


### PR DESCRIPTION
- Bumps the Dockerfile base build image to `golang:1.11.1`
- Bumps the Dockerfile running container image to `alpine:3.8`
- Fixes the readme instructions to run the tests