### PR TITLE
Corrected example ACR URL comment.

### DIFF
--- a/apis/poi/charts/mydrive-poi/values.yaml
+++ b/apis/poi/charts/mydrive-poi/values.yaml
@@ -12,7 +12,7 @@ green:
 
 replicaCount: 2
 repository:
-  # Fully qualified path to image in ACR (Ex. youracr.azureacr.io/devopsoh/poi-build).
+  # Fully qualified path to image in ACR (Ex. youracr.azurecr.io/devopsoh/poi-build).
   # See deployment scripts in https://github.com/Azure-Samples/openhack-devops-proctor for example usage.
   image:
   pullPolicy: Always


### PR DESCRIPTION


## Purpose
Example incorrectly provides azureacr.io as the root ACR domain. This typo has caused difficult-to-diagnose issues when working through the DevOps OH. Corrected root ACR domain to be azurecr.io.

## Does this introduce a breaking change?
[ ] Yes
[X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:

## How to Test
* Update the values.yaml to use an ACR image path using the corrected ACR domain name (azurecr.io).
* Deploy the Helm chart.

## What to Check
* That the example root ACR domain has been corrected to azurecr.io.

## Other Information
