### PR TITLE
Adds Devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,64 @@
+FROM debian:buster
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt, install base packages, SDKs & tools
+RUN apt-get update \
+    && apt-get install -y git less procps lsb-release curl wget ca-certificates apt-transport-https gnupg \
+    && curl -sL https://packages.microsoft.com/config/debian/9/prod.list -o /etc/apt/sources.list.d/microsoft-prod.list \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ buster main" | tee /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update \
+    && apt-get install -y azure-cli openjdk-11-jdk dotnet-sdk-2.2
+
+# Golang
+WORKDIR /tmp
+RUN curl -fsS https://dl.google.com/go/go1.14.1.linux-amd64.tar.gz -o golang.tar.gz \
+    && tar -xvf golang.tar.gz \
+    && rm -rf /usr/local/go \
+    && mv go /usr/local
+ENV GO111MODULE=on
+ENV CGO_ENABLED=0
+
+# Maven
+RUN curl -sSL https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o maven.tar.gz \
+    && tar -xzf maven.tar.gz \
+    && mv apache-maven-3.6.3 /opt \
+    && rm maven.tar.gz
+
+# Node 12.x
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && apt-get install -y nodejs
+
+# Docker client
+RUN curl -sSL https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz -o docker.tgz \
+    && tar -zxvf docker.tgz docker/docker \
+    && chmod +x docker/docker \
+    && mv docker/docker /usr/bin/docker \
+    && rm -rf docker \
+    && rm docker.tgz
+
+# Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && groupadd docker || true \
+    && usermod -aG docker $USERNAME
+
+# Cleanup apt
+RUN apt-get autoremove -y \
+    && apt-get clean -y 
+
+# Paths and user set up
+RUN echo 'export PATH="$HOME/go/bin:/usr/local/go/bin:/opt/apache-maven-3.6.3/bin:$PATH"' >> /etc/bash.bashrc
+RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64' >> /etc/bash.bashrc
+WORKDIR /home/$USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+	"name": "DevOps OpenHack",
+	"dockerFile": "Dockerfile",
+	//"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	// Docker in docker
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"redhat.vscode-yaml",
+		"github.vscode-pull-request-github",
+		"ms-vscode.azure-account",
+		"ms-azuretools.vscode-azureappservice"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This adds a Dockerfile and Devcontainer config, to allow the repo to be run either in VSCode remote containers or Codespaces

The container includes
- Basic tools like git, wget, curl
- Go 1.14
- .NET Core 2.2 SDK
- JDK 11
- Node 12
- Maven
- Azure CLI
- Docker (client only)

This should allow people to at least run the unit tests locally (without CI) should they need too, also have git and Azure CLI

A few extensions are enabled also (Azure Web Apps, GitHub, YAML)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other: Dev environment and tooling
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
- Have remote container enabled in VS Code https://code.visualstudio.com/docs/remote/containers
- Open the folder/repo in VSCode pick "open in container" when prompted
- Alternatively. Use VS Codespaces https://aka.ms/vso-login and create a codespace from this repo+branch
```

## What to Check
Verify that the following are valid
- You can run local unit tests against the four APIs, e.g. `node`, `mvn`, `go`, and `dotnet` commands all work

## Other Information
<!-- Add any other helpful information that may be needed here. -->