### PR TITLE
Fixes for Userprofile unit tests

### DIFF
--- a/apis/userprofile/config/swagger.json
+++ b/apis/userprofile/config/swagger.json
@@ -48,7 +48,7 @@
                     "default": {
                         "description": "An error occurred",
                         "schema": {
-                            "$ref": "#/definitions/error_response_default"
+                            "$ref": "#/definitions/DefaultErrorResponse"
                         }
                     }
                 }
@@ -294,6 +294,20 @@
                 }
             }
         },
+        "DefaultErrorResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "description": "Error code (if available)",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "description": "Error Message",
+                    "type": "string"
+                }
+            }
+        },        
         "DefaultResponse": {
           "type": "object",
           "properties": {

--- a/apis/userprofile/package.json
+++ b/apis/userprofile/package.json
@@ -47,6 +47,7 @@
     },
     "scripts": {
         "test": "tape 'tests/**/*.js' | tap-junit --output reports --name userprofile-report",
+        "test-noreport": "tape 'tests/**/*.js'",
         "cover": "nyc tape -- 'tests/**/*.js' --cov",
         "lint": "eslint .",
         "regenerate": "yo swaggerize:test --framework express --apiPath './config/swagger.json'"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Running unit tests for the userprofile API would result in error
```
/home/ben/dev/devops-dryrun/openhack-devops-team/apis/userprofile/tests/healthcheck/user.js:42
                t.ok(mock.request);
                          ^
TypeError: Cannot read property 'request' of undefined
```
This error is misleading the root cause was a problem with the swagger and an invalid definition reference. 

To see the error you needed to run tape without the result piped into the report generation 

This PR fixes the error in `config/swagger.json` and adds `test-noreport` script to `package.json` to make it easier to see what is happening when running the tests

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd apis/userprofile
npm run test
npm run test-noreport
```

## What to Check
Tests pass

## Other Information
<!-- Add any other helpful information that may be needed here. -->